### PR TITLE
Added options for US433 and US433-wide.

### DIFF
--- a/src/components/RFSelect.vue
+++ b/src/components/RFSelect.vue
@@ -15,7 +15,9 @@ const domains = [
   {value: 2, title: 'EU868'},
   {value: 3, title: 'IN866'},
   {value: 4, title: 'AU433'},
-  {value: 5, title: 'EU433'}
+  {value: 5, title: 'EU433'},
+  {value: 6, title: 'US433'},
+  {value: 7, title: 'US433-Wide'}
 ]
 
 function hasHighFrequency() {


### PR DESCRIPTION
I found that the online site supports burning EU433 firmware, but the US433 and US433-wide are missing, I am not sure if the developer team has other considerations, so the team did not add them. If I accidentally left out these two options, I have now added them.
![修改后](https://github.com/user-attachments/assets/a9d2db6d-5ea0-48ea-addf-be20b04e9b55)
